### PR TITLE
Fix issues #12 and #13.

### DIFF
--- a/winloop/errors.pyx
+++ b/winloop/errors.pyx
@@ -1,4 +1,4 @@
-# cython:langauge_level = 3
+# cython:language_level = 3
 from libc.string cimport strerror 
 # from includes._stdlib cimport *
 from .includes cimport uv , system

--- a/winloop/handles/stream.pyx
+++ b/winloop/handles/stream.pyx
@@ -570,7 +570,7 @@ cdef class UVStream(UVBaseTransport):
                         self._buffer_size = 0
                         return
 
-                elif err != uv.EAGAIN:
+                elif err != -4088:  # for now, use -4088 directly, instead of uv.EAGAIN (which is equal to 11)
                     ctx.close()
                     # print("Something failed in line 519 uv.uv_try_write")
                     exc = convert_error(err)
@@ -786,7 +786,7 @@ cdef inline bint __uv_stream_on_read_common(UVStream sc, Loop loop,
         sc.__reading_stopped()  # Just in case.
         return True
 
-    if nread == uv.EOF:
+    if nread == -4095:  # for now, use -4095 directly, instead of uv.EOF (which is equal to -1)
         # From libuv docs:
         #     The callee is responsible for stopping closing the stream
         #     when an error happens by calling uv_read_stop() or uv_close().


### PR DESCRIPTION
For now, using hard coded error numbers.

Problems are caused by different assignment to error numbers on Windows (vs Unix).