### PR TITLE
Preparations for BaseEventLoopPolicy's Removal in 3.14

### DIFF
--- a/winloop/__init__.py
+++ b/winloop/__init__.py
@@ -3,7 +3,7 @@ import typing as _typing
 import sys as _sys
 import warnings as _warnings
 
-if _sys.version_info <= (3, 13)
+if _sys.version_info <= (3, 13):
     from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
 else:
     # Python Deprecates EventLoopPolicy in 3.14

--- a/winloop/__init__.py
+++ b/winloop/__init__.py
@@ -3,7 +3,14 @@ import typing as _typing
 import sys as _sys
 import warnings as _warnings
 
-from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+if _sys.version_info <= (3, 13)
+    from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+else:
+    # Python Deprecates EventLoopPolicy in 3.14
+    # SEE: https://github.com/python/cpython/issues/131148
+    # We will watch closely to determine what else we will do for supporting 3.14
+    from asyncio.events import _BaseDefaultEventLoopPolicy as __BasePolicy
+
 
 # Winloop comment: next line commented out for now. Somehow winloop\includes
 # is not included in the Winloop wheel, affecting version 0.1.6 on PyPI.


### PR DESCRIPTION
I was going through https://github.com/MagicStack/uvloop/issues/637 and it seems this might be a threat to us as well.

https://github.com/python/cpython/issues/131148 
I'll be watching the uvloop pull requests for 3.14 closely so we can figure out how we can support 3.14 ourselves later down the road. For now this change is the best I've got.
