### PR TITLE
Create dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This new pull request adds dependabot to winloop to help fix workflows and update pip package versions so that we don't have to do anything annoying on our ends ever again. I optimized this to be done weekly because the only thing outside of here that I ever have is an IRL part-time job that only ever takes up my evenings and that is it (Currently out of job until august/september because building is getting redone) other than that reviewing dependabot should be a breeze unless another contributors have other thoughts or feedback. Were always happy to have new contributors and I am willing to deviate from uvloop a bit in order to keep my project alive and healthy.