### PR TITLE
build fixes for mingw

### DIFF
--- a/winloop/handles/pipe.pyx
+++ b/winloop/handles/pipe.pyx
@@ -1,3 +1,5 @@
+from libc.stdint cimport uintptr_t
+
 cdef __pipe_init_uv_handle(UVStream handle, Loop loop):
     cdef int err
 
@@ -25,7 +27,7 @@ cdef __pipe_init_uv_handle(UVStream handle, Loop loop):
 cdef __pipe_open(UVStream handle, int fd):
     cdef int err
     err = uv.uv_pipe_open(<uv.uv_pipe_t *>handle._handle,
-                          <uv.uv_os_fd_t>fd)
+                          <uintptr_t> <uv.uv_os_fd_t>fd)
     if err < 0:
         exc = convert_error(err)
         raise exc

--- a/winloop/loop.pyx
+++ b/winloop/loop.pyx
@@ -18,7 +18,7 @@ from cpython.pythread cimport PyThread_get_thread_ident
 from cpython.ref cimport Py_DECREF, Py_INCREF, Py_XDECREF, Py_XINCREF
 from cpython.set cimport PySet_Add, PySet_Discard
 from libc cimport errno
-from libc.stdint cimport uint64_t
+from libc.stdint cimport uint64_t, uintptr_t
 from libc.string cimport memcpy, memset, strerror
 
 from .includes cimport system, uv
@@ -1172,7 +1172,7 @@ cdef class Loop:
 
     def _get_backend_id(self):
         """This method is used by uvloop tests and is not part of the API."""
-        return uv.uv_backend_fd(self.uvloop)
+        return int(<uintptr_t> uv.uv_backend_fd(self.uvloop))
 
     cdef _print_debug_info(self):
         cdef:


### PR DESCRIPTION
* enable `use_system_libuv` by default on mingw,
* mingw toolchain expects gcc style linker arguments: `-lLIB`,
* use explicit casts to avoid _makes integer from pointer without a cast_ errors

Supersedes #60

Note: this is unrelated to #64 which broke separately.