### PR TITLE
drop 3.9 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,13 +15,10 @@ jobs:
       matrix:
 
         os: [windows-latest, windows-11-arm]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         exclude:
           - os: windows-11-arm  # setup-python action only supports 3.11+
-            python-version: '3.9'
-          - os: windows-11-arm  # setup-python action only supports 3.11+
             python-version: '3.10'
-        
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

Drops 3.9 support due to external libraries dropping support for 3.9

## Are there changes in behavior for the user?

3.9 will no longer be in use and it's encouraged to move to 3.10 or later...

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
