### PR TITLE
upgrade annotations to be 3.10 styled, remove some more deprecated things and reformat code with ruff.

### DIFF
--- a/examples/bench/echoclient.py
+++ b/examples/bench/echoclient.py
@@ -9,53 +9,51 @@ import ssl
 import time
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--msize', default=1000, type=int,
-                        help='message size in bytes')
-    parser.add_argument('--mpr', default=1, type=int,
-                        help='messages per request')
-    parser.add_argument('--num', default=200000, type=int,
-                        help='number of messages')
-    parser.add_argument('--times', default=1, type=int,
-                        help='number of times to run the test')
-    parser.add_argument('--workers', default=3, type=int,
-                        help='number of workers')
-    parser.add_argument('--addr', default='127.0.0.1:25000', type=str,
-                        help='address:port of echoserver')
-    parser.add_argument('--ssl', default=False, action='store_true')
+    parser.add_argument("--msize", default=1000, type=int, help="message size in bytes")
+    parser.add_argument("--mpr", default=1, type=int, help="messages per request")
+    parser.add_argument("--num", default=200000, type=int, help="number of messages")
+    parser.add_argument(
+        "--times", default=1, type=int, help="number of times to run the test"
+    )
+    parser.add_argument("--workers", default=3, type=int, help="number of workers")
+    parser.add_argument(
+        "--addr", default="127.0.0.1:25000", type=str, help="address:port of echoserver"
+    )
+    parser.add_argument("--ssl", default=False, action="store_true")
     args = parser.parse_args()
 
     client_context = None
     if args.ssl:
-        print('with SSL')
-        if hasattr(ssl, 'PROTOCOL_TLS'):
+        print("with SSL")
+        if hasattr(ssl, "PROTOCOL_TLS"):
             client_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         else:
             client_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        if hasattr(client_context, 'check_hostname'):
+        if hasattr(client_context, "check_hostname"):
             client_context.check_hostname = False
         client_context.verify_mode = ssl.CERT_NONE
 
     unix = False
-    if args.addr.startswith('file:'):
+    if args.addr.startswith("file:"):
         unix = True
         addr = args.addr[5:]
     else:
-        addr = args.addr.split(':')
+        addr = args.addr.split(":")
         addr[1] = int(addr[1])
         addr = tuple(addr)
-    print('will connect to: {}'.format(addr))
+    print("will connect to: {}".format(addr))
 
     MSGSIZE = args.msize
     REQSIZE = MSGSIZE * args.mpr
 
-    msg = b'x' * (MSGSIZE - 1) + b'\n'
+    msg = b"x" * (MSGSIZE - 1) + b"\n"
     if args.mpr:
         msg *= args.mpr
 
     def run_test(n):
-        print('Sending', NMESSAGES, 'messages')
+        print("Sending", NMESSAGES, "messages")
         if args.mpr:
             n //= args.mpr
 
@@ -96,5 +94,5 @@ if __name__ == '__main__':
                 e.submit(run_test, NMESSAGES)
     end = time.time()
     duration = end - start
-    print(NMESSAGES * N * TIMES, 'in', duration)
-    print(NMESSAGES * N * TIMES / duration, 'requests/sec')
+    print(NMESSAGES * N * TIMES, "in", duration)
+    print(NMESSAGES * N * TIMES / duration, "requests/sec")

--- a/examples/bench/echoserver.py
+++ b/examples/bench/echoserver.py
@@ -20,12 +20,12 @@ async def echo_server(loop, address, unix):
     sock.listen(5)
     sock.setblocking(False)
     if PRINT:
-        print('Server listening at', address)
+        print("Server listening at", address)
     with sock:
         while True:
             client, addr = await loop.sock_accept(sock)
             if PRINT:
-                print('Connection from', addr)
+                print("Connection from", addr)
             loop.create_task(echo_client(loop, client))
 
 
@@ -42,24 +42,24 @@ async def echo_client(loop, client):
                 break
             await loop.sock_sendall(client, data)
     if PRINT:
-        print('Connection closed')
+        print("Connection closed")
 
 
 async def echo_client_streams(reader, writer):
-    sock = writer.get_extra_info('socket')
+    sock = writer.get_extra_info("socket")
     try:
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     except (OSError, NameError):
         pass
     if PRINT:
-        print('Connection from', sock.getpeername())
+        print("Connection from", sock.getpeername())
     while True:
         data = await reader.read(1000000)
         if not data:
             break
         writer.write(data)
     if PRINT:
-        print('Connection closed')
+        print("Connection closed")
     writer.close()
 
 
@@ -98,24 +98,25 @@ async def print_debug(loop):
         await asyncio.sleep(0.5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--uvloop', default=False, action='store_true')
-    parser.add_argument('--streams', default=False, action='store_true')
-    parser.add_argument('--proto', default=False, action='store_true')
-    parser.add_argument('--addr', default='127.0.0.1:25000', type=str)
-    parser.add_argument('--print', default=False, action='store_true')
-    parser.add_argument('--ssl', default=False, action='store_true')
-    parser.add_argument('--buffered', default=False, action='store_true')
+    parser.add_argument("--uvloop", default=False, action="store_true")
+    parser.add_argument("--streams", default=False, action="store_true")
+    parser.add_argument("--proto", default=False, action="store_true")
+    parser.add_argument("--addr", default="127.0.0.1:25000", type=str)
+    parser.add_argument("--print", default=False, action="store_true")
+    parser.add_argument("--ssl", default=False, action="store_true")
+    parser.add_argument("--buffered", default=False, action="store_true")
     args = parser.parse_args()
 
     if args.uvloop:
         import winloop as uvloop
+
         loop = uvloop.new_event_loop()
-        print('using UVLoop')
+        print("using UVLoop")
     else:
         loop = asyncio.new_event_loop()
-        print('using asyncio loop')
+        print("using asyncio loop")
 
     asyncio.set_event_loop(loop)
     loop.set_debug(False)
@@ -123,88 +124,93 @@ if __name__ == '__main__':
     if args.print:
         PRINT = 1
 
-    if hasattr(loop, 'print_debug_info'):
+    if hasattr(loop, "print_debug_info"):
         loop.create_task(print_debug(loop))
         PRINT = 0
 
     unix = False
-    if args.addr.startswith('file:'):
+    if args.addr.startswith("file:"):
         unix = True
         addr = args.addr[5:]
         if os.path.exists(addr):
             os.remove(addr)
     else:
-        addr = args.addr.split(':')
+        addr = args.addr.split(":")
         addr[1] = int(addr[1])
         addr = tuple(addr)
 
-    print('serving on: {}'.format(addr))
+    print("serving on: {}".format(addr))
 
     server_context = None
     if args.ssl:
-        print('with SSL')
-        if hasattr(ssl, 'PROTOCOL_TLS'):
+        print("with SSL")
+        if hasattr(ssl, "PROTOCOL_TLS"):
             server_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         else:
             server_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         server_context.load_cert_chain(
-            (pathlib.Path(__file__).parent.parent.parent /
-                'tests' / 'certs' / 'ssl_cert.pem'),
-            (pathlib.Path(__file__).parent.parent.parent /
-                'tests' / 'certs' / 'ssl_key.pem'))
-        if hasattr(server_context, 'check_hostname'):
+            (
+                pathlib.Path(__file__).parent.parent.parent
+                / "tests"
+                / "certs"
+                / "ssl_cert.pem"
+            ),
+            (
+                pathlib.Path(__file__).parent.parent.parent
+                / "tests"
+                / "certs"
+                / "ssl_key.pem"
+            ),
+        )
+        if hasattr(server_context, "check_hostname"):
             server_context.check_hostname = False
         server_context.verify_mode = ssl.CERT_NONE
 
     if args.streams:
         if args.proto:
-            print('cannot use --stream and --proto simultaneously')
+            print("cannot use --stream and --proto simultaneously")
             exit(1)
 
         if args.buffered:
-            print('cannot use --stream and --buffered simultaneously')
+            print("cannot use --stream and --buffered simultaneously")
             exit(1)
 
-        print('using asyncio/streams')
+        print("using asyncio/streams")
         if unix:
-            coro = asyncio.start_unix_server(echo_client_streams,
-                                             addr,
-                                             ssl=server_context)
+            coro = asyncio.start_unix_server(
+                echo_client_streams, addr, ssl=server_context
+            )
         else:
-            coro = asyncio.start_server(echo_client_streams,
-                                        *addr,
-                                        ssl=server_context)
+            coro = asyncio.start_server(echo_client_streams, *addr, ssl=server_context)
         srv = loop.run_until_complete(coro)
     elif args.proto:
         if args.streams:
-            print('cannot use --stream and --proto simultaneously')
+            print("cannot use --stream and --proto simultaneously")
             exit(1)
 
         if args.buffered:
-            print('using buffered protocol')
+            print("using buffered protocol")
             protocol = EchoBufferedProtocol
         else:
-            print('using simple protocol')
+            print("using simple protocol")
             protocol = EchoProtocol
 
         if unix:
-            coro = loop.create_unix_server(protocol, addr,
-                                           ssl=server_context)
+            coro = loop.create_unix_server(protocol, addr, ssl=server_context)
         else:
-            coro = loop.create_server(protocol, *addr,
-                                      ssl=server_context)
+            coro = loop.create_server(protocol, *addr, ssl=server_context)
         srv = loop.run_until_complete(coro)
     else:
         if args.ssl:
-            print('cannot use SSL for loop.sock_* methods')
+            print("cannot use SSL for loop.sock_* methods")
             exit(1)
 
-        print('using sock_recv/sock_sendall')
+        print("using sock_recv/sock_sendall")
         loop.create_task(echo_server(loop, addr, unix))
     try:
         loop.run_forever()
     finally:
-        if hasattr(loop, 'print_debug_info'):
+        if hasattr(loop, "print_debug_info"):
             gc.collect()
             print(chr(27) + "[2J")
             loop.print_debug_info()

--- a/examples/bench/rlserver.py
+++ b/examples/bench/rlserver.py
@@ -9,21 +9,20 @@ PRINT = 0
 
 
 async def echo_client_streams(reader, writer):
-    sock = writer.get_extra_info('socket')
+    sock = writer.get_extra_info("socket")
     try:
-        sock.setsockopt(
-            stdsock.IPPROTO_TCP, stdsock.TCP_NODELAY, 1)
+        sock.setsockopt(stdsock.IPPROTO_TCP, stdsock.TCP_NODELAY, 1)
     except (OSError, NameError):
         pass
     if PRINT:
-        print('Connection from', sock.getpeername())
+        print("Connection from", sock.getpeername())
     while True:
         data = await reader.readline()
         if not data:
             break
         writer.write(data)
     if PRINT:
-        print('Connection closed')
+        print("Connection closed")
     writer.close()
 
 
@@ -34,20 +33,21 @@ async def print_debug(loop):
         await asyncio.sleep(0.5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--uvloop', default=False, action='store_true')
-    parser.add_argument('--addr', default='127.0.0.1:25000', type=str)
-    parser.add_argument('--print', default=False, action='store_true')
+    parser.add_argument("--uvloop", default=False, action="store_true")
+    parser.add_argument("--addr", default="127.0.0.1:25000", type=str)
+    parser.add_argument("--print", default=False, action="store_true")
     args = parser.parse_args()
 
     if args.uvloop:
         import winloop as uvloop
+
         loop = uvloop.new_event_loop()
-        print('using UVLoop')
+        print("using UVLoop")
     else:
         loop = asyncio.new_event_loop()
-        print('using asyncio loop')
+        print("using asyncio loop")
 
     asyncio.set_event_loop(loop)
     loop.set_debug(False)
@@ -55,37 +55,35 @@ if __name__ == '__main__':
     if args.print:
         PRINT = 1
 
-    if hasattr(loop, 'print_debug_info'):
+    if hasattr(loop, "print_debug_info"):
         loop.create_task(print_debug(loop))
         PRINT = 0
 
     unix = False
-    if args.addr.startswith('file:'):
+    if args.addr.startswith("file:"):
         unix = True
         addr = args.addr[5:]
         if os.path.exists(addr):
             os.remove(addr)
     else:
-        addr = args.addr.split(':')
+        addr = args.addr.split(":")
         addr[1] = int(addr[1])
         addr = tuple(addr)
 
-    print('readline performance test')
-    print('serving on: {}'.format(addr))
+    print("readline performance test")
+    print("serving on: {}".format(addr))
 
-    print('using asyncio/streams')
+    print("using asyncio/streams")
     if unix:
-        coro = asyncio.start_unix_server(echo_client_streams,
-                                         addr, limit=256000)
+        coro = asyncio.start_unix_server(echo_client_streams, addr, limit=256000)
     else:
-        coro = asyncio.start_server(echo_client_streams,
-                                    *addr, limit=256000)
+        coro = asyncio.start_server(echo_client_streams, *addr, limit=256000)
     srv = loop.run_until_complete(coro)
 
     try:
         loop.run_forever()
     finally:
-        if hasattr(loop, 'print_debug_info'):
+        if hasattr(loop, "print_debug_info"):
             gc.collect()
             print(chr(27) + "[2J")
             loop.print_debug_info()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,7 @@ build-frontend = "build"
 addopts = "--capture=no --assert=plain --strict-markers --tb=native --import-mode=importlib"
 testpaths = "tests"
 filterwarnings = "default"
+
+[tool.ruff.lint]
+# Upgrade annotations
+select = ["UP045", "UP007", "UP035"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 
 vi = sys.version_info
 if vi < (3, 8):
-    raise RuntimeError('winloop requires Python 3.8 or greater')
+    raise RuntimeError("winloop requires Python 3.8 or greater")
 
 # Winloop comment: winloop now supports both Windows and non-Windows.
 # Below uvloop's setup.py is merged with winloop's previous setup.py.
@@ -20,14 +20,14 @@ from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
 
-# Using a newer version of cython since versions are no longer a threat. 
-# Cython Decided to keep DEF Statements. 
-CYTHON_DEPENDENCY = 'Cython>=3.1.2'
+# Using a newer version of cython since versions are no longer a threat.
+# Cython Decided to keep DEF Statements.
+CYTHON_DEPENDENCY = "Cython>=3.1.2"
 MACHINE = platform.machine()
-MODULES_CFLAGS = [os.getenv('UVLOOP_OPT_CFLAGS', '-O2')]
+MODULES_CFLAGS = [os.getenv("UVLOOP_OPT_CFLAGS", "-O2")]
 _ROOT = pathlib.Path(__file__).parent
-LIBUV_DIR = str(_ROOT / 'vendor' / 'libuv')
-LIBUV_BUILD_DIR = str(_ROOT / 'build' / 'libuv-{}'.format(MACHINE))
+LIBUV_DIR = str(_ROOT / "vendor" / "libuv")
+LIBUV_BUILD_DIR = str(_ROOT / "build" / "libuv-{}".format(MACHINE))
 
 MINGW = bool(os.environ.get("MINGW_PREFIX", ""))
 
@@ -35,32 +35,32 @@ MINGW = bool(os.environ.get("MINGW_PREFIX", ""))
 def _libuv_build_env():
     env = os.environ.copy()
 
-    cur_cflags = env.get('CFLAGS', '')
-    if not re.search(r'-O\d', cur_cflags):
-        cur_cflags += ' -O2'
+    cur_cflags = env.get("CFLAGS", "")
+    if not re.search(r"-O\d", cur_cflags):
+        cur_cflags += " -O2"
 
-    env['CFLAGS'] = (cur_cflags + ' -fPIC ' + env.get('ARCHFLAGS', ''))
+    env["CFLAGS"] = cur_cflags + " -fPIC " + env.get("ARCHFLAGS", "")
 
     return env
 
 
 def _libuv_autogen(env):
-    if os.path.exists(os.path.join(LIBUV_DIR, 'configure')):
+    if os.path.exists(os.path.join(LIBUV_DIR, "configure")):
         # No need to use autogen, the configure script is there.
         return
 
-    if not os.path.exists(os.path.join(LIBUV_DIR, 'autogen.sh')):
+    if not os.path.exists(os.path.join(LIBUV_DIR, "autogen.sh")):
         raise RuntimeError(
-            'the libuv submodule has not been checked out; '
-            'try running "git submodule init; git submodule update"')
+            "the libuv submodule has not been checked out; "
+            'try running "git submodule init; git submodule update"'
+        )
 
-    subprocess.run(
-        ['/bin/sh', 'autogen.sh'], cwd=LIBUV_DIR, env=env, check=True)
+    subprocess.run(["/bin/sh", "autogen.sh"], cwd=LIBUV_DIR, env=env, check=True)
 
 
 class uvloop_sdist(sdist):
     def run(self):
-        if sys.platform != 'win32':
+        if sys.platform != "win32":
             # Make sure sdist archive contains configure
             # to avoid the dependency on autotools.
             _libuv_autogen(_libuv_build_env())
@@ -69,20 +69,24 @@ class uvloop_sdist(sdist):
 
 class uvloop_build_ext(build_ext):
     user_options = build_ext.user_options + [
-        ('cython-always', None,
-            'run cythonize() even if .c files are present'),
-        ('cython-annotate', None,
-            'Produce a colorized HTML version of the Cython source.'),
-        ('cython-directives=', None,
-            'Cythion compiler directives'),
-        ('use-system-libuv', None,
-            'Use the system provided libuv, instead of the bundled one'),
+        ("cython-always", None, "run cythonize() even if .c files are present"),
+        (
+            "cython-annotate",
+            None,
+            "Produce a colorized HTML version of the Cython source.",
+        ),
+        ("cython-directives=", None, "Cythion compiler directives"),
+        (
+            "use-system-libuv",
+            None,
+            "Use the system provided libuv, instead of the bundled one",
+        ),
     ]
 
     boolean_options = build_ext.boolean_options + [
-        'cython-always',
-        'cython-annotate',
-        'use-system-libuv',
+        "cython-always",
+        "cython-annotate",
+        "use-system-libuv",
     ]
 
     def initialize_options(self):
@@ -98,9 +102,9 @@ class uvloop_build_ext(build_ext):
 
         for extension in self.distribution.ext_modules:
             for i, sfile in enumerate(extension.sources):
-                if sfile.endswith('.pyx'):
+                if sfile.endswith(".pyx"):
                     prefix, ext = os.path.splitext(sfile)
-                    cfile = prefix + '.c'
+                    cfile = prefix + ".c"
 
                     if os.path.exists(cfile) and not self.cython_always:
                         extension.sources[i] = cfile
@@ -122,25 +126,28 @@ class uvloop_build_ext(build_ext):
                 import Cython
             except ImportError:
                 raise RuntimeError(
-                    'please install {} to compile uvloop from source'.format(
-                        CYTHON_DEPENDENCY))
+                    "please install {} to compile uvloop from source".format(
+                        CYTHON_DEPENDENCY
+                    )
+                )
 
             cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
             if Cython.__version__ not in cython_dep:
                 raise RuntimeError(
-                    'uvloop requires {}, got Cython=={}'.format(
+                    "uvloop requires {}, got Cython=={}".format(
                         CYTHON_DEPENDENCY, Cython.__version__
-                    ))
+                    )
+                )
 
             from Cython.Build import cythonize
 
             directives = {}
             if self.cython_directives:
-                for directive in self.cython_directives.split(','):
-                    k, _, v = directive.partition('=')
-                    if v.lower() == 'false':
+                for directive in self.cython_directives.split(","):
+                    k, _, v = directive.partition("=")
+                    if v.lower() == "false":
                         v = False
-                    if v.lower() == 'true':
+                    if v.lower() == "true":
                         v = True
 
                     directives[k] = v
@@ -151,7 +158,8 @@ class uvloop_build_ext(build_ext):
                 compiler_directives=directives,
                 annotate=self.cython_annotate,
                 compile_time_env=dict(DEFAULT_FREELIST_SIZE=250),
-                emit_linenums=self.debug)
+                emit_linenums=self.debug,
+            )
 
         super().finalize_options()
 
@@ -171,134 +179,140 @@ class uvloop_build_ext(build_ext):
         # Sometimes pip fails to preserve the timestamps correctly,
         # in which case, make will try to run autotools again.
         subprocess.run(
-            ['touch', 'configure.ac', 'aclocal.m4', 'configure',
-             'Makefile.am', 'Makefile.in'],
-            cwd=LIBUV_BUILD_DIR, env=env, check=True)
+            [
+                "touch",
+                "configure.ac",
+                "aclocal.m4",
+                "configure",
+                "Makefile.am",
+                "Makefile.in",
+            ],
+            cwd=LIBUV_BUILD_DIR,
+            env=env,
+            check=True,
+        )
 
-        if 'LIBUV_CONFIGURE_HOST' in env:
-            cmd = ['./configure', '--host=' + env['LIBUV_CONFIGURE_HOST']]
+        if "LIBUV_CONFIGURE_HOST" in env:
+            cmd = ["./configure", "--host=" + env["LIBUV_CONFIGURE_HOST"]]
         else:
-            cmd = ['./configure']
-        subprocess.run(
-            cmd,
-            cwd=LIBUV_BUILD_DIR, env=env, check=True)
+            cmd = ["./configure"]
+        subprocess.run(cmd, cwd=LIBUV_BUILD_DIR, env=env, check=True)
 
         try:
             njobs = len(os.sched_getaffinity(0))
         except AttributeError:
             njobs = os.cpu_count()
-        j_flag = '-j{}'.format(njobs or 1)
-        c_flag = "CFLAGS={}".format(env['CFLAGS'])
+        j_flag = "-j{}".format(njobs or 1)
+        c_flag = "CFLAGS={}".format(env["CFLAGS"])
         subprocess.run(
-            ['make', j_flag, c_flag],
-            cwd=LIBUV_BUILD_DIR, env=env, check=True)
+            ["make", j_flag, c_flag], cwd=LIBUV_BUILD_DIR, env=env, check=True
+        )
 
     def build_extensions(self):
-        if sys.platform == 'win32' and not MINGW:
+        if sys.platform == "win32" and not MINGW:
             path = pathlib.Path("vendor", "libuv", "src")
-            c_files = [p.as_posix() for p in path.iterdir() if p.suffix == '.c']
-            c_files += [p.as_posix() for p in (path/'win').iterdir() if p.suffix == '.c']
+            c_files = [p.as_posix() for p in path.iterdir() if p.suffix == ".c"]
+            c_files += [
+                p.as_posix() for p in (path / "win").iterdir() if p.suffix == ".c"
+            ]
             self.extensions[-1].sources += c_files
             super().build_extensions()
             return
 
         if self.use_system_libuv:
-            self.compiler.add_library('uv')
+            self.compiler.add_library("uv")
 
-            if sys.platform == 'darwin' and \
-                    os.path.exists('/opt/local/include'):
+            if sys.platform == "darwin" and os.path.exists("/opt/local/include"):
                 # Support macports on Mac OS X.
-                self.compiler.add_include_dir('/opt/local/include')
+                self.compiler.add_include_dir("/opt/local/include")
         else:
-            libuv_lib = os.path.join(LIBUV_BUILD_DIR, '.libs', 'libuv.a')
+            libuv_lib = os.path.join(LIBUV_BUILD_DIR, ".libs", "libuv.a")
             if not os.path.exists(libuv_lib):
                 self.build_libuv()
             if not os.path.exists(libuv_lib):
-                raise RuntimeError('failed to build libuv')
+                raise RuntimeError("failed to build libuv")
 
             self.extensions[-1].extra_objects.extend([libuv_lib])
-            self.compiler.add_include_dir(os.path.join(LIBUV_DIR, 'include'))
+            self.compiler.add_include_dir(os.path.join(LIBUV_DIR, "include"))
 
-        if sys.platform.startswith('linux'):
-            self.compiler.add_library('rt')
-        elif sys.platform.startswith(('freebsd', 'dragonfly')):
-            self.compiler.add_library('kvm')
-        elif sys.platform.startswith('sunos'):
-            self.compiler.add_library('kstat')
+        if sys.platform.startswith("linux"):
+            self.compiler.add_library("rt")
+        elif sys.platform.startswith(("freebsd", "dragonfly")):
+            self.compiler.add_library("kvm")
+        elif sys.platform.startswith("sunos"):
+            self.compiler.add_library("kstat")
 
-        self.compiler.add_library('pthread')
+        self.compiler.add_library("pthread")
 
         super().build_extensions()
 
 
-with open(str(_ROOT / 'winloop' / '_version.py')) as f:
+with open(str(_ROOT / "winloop" / "_version.py")) as f:
     for line in f:
-        if line.startswith('__version__ ='):
-            _, _, version = line.partition('=')
+        if line.startswith("__version__ ="):
+            _, _, version = line.partition("=")
             VERSION = version.strip(" \n'\"")
             break
     else:
-        raise RuntimeError(
-            'unable to read the version from winloop/_version.py')
+        raise RuntimeError("unable to read the version from winloop/_version.py")
 
 
-if sys.platform == 'win32':
+if sys.platform == "win32":
     from Cython.Build import cythonize
     from Cython.Compiler.Main import default_options
 
-    default_options['compile_time_env'] = dict(DEFAULT_FREELIST_SIZE=250)
-    ext = cythonize([
+    default_options["compile_time_env"] = dict(DEFAULT_FREELIST_SIZE=250)
+    ext = cythonize(
+        [
+            Extension(
+                "winloop.loop",
+                sources=["winloop/loop.pyx"],
+                include_dirs=[]
+                if MINGW
+                else [
+                    "vendor/libuv/src",
+                    "vendor/libuv/src/win",
+                    "vendor/libuv/include",
+                ],
+                # subset of libuv Windows libraries:
+                extra_link_args=[
+                    (f"-l{lib}" if MINGW else f"{lib}.lib")
+                    for lib in (
+                        "Shell32",
+                        "Ws2_32",
+                        "Advapi32",
+                        "iphlpapi",
+                        "Userenv",
+                        "User32",
+                        "Dbghelp",
+                        "Ole32",
+                    )
+                ],
+                define_macros=[("WIN32_LEAN_AND_MEAN", 1), ("_WIN32_WINNT", "0x0602")],
+            ),
+        ]
+    )
+else:
+    ext = [
         Extension(
             "winloop.loop",
             sources=[
-                "winloop/loop.pyx"
+                "winloop/loop.pyx",
             ],
-            include_dirs=[] if MINGW else [
-                "vendor/libuv/src",
-                "vendor/libuv/src/win",
-                "vendor/libuv/include"
-            ],
-            # subset of libuv Windows libraries:
-            extra_link_args=[(f"-l{lib}" if MINGW else f"{lib}.lib") for lib in (
-                "Shell32",
-                "Ws2_32",
-                "Advapi32",
-                "iphlpapi",
-                "Userenv",
-                "User32",
-                "Dbghelp",
-                "Ole32",
-            )],
-            define_macros=[
-                ("WIN32_LEAN_AND_MEAN", 1),
-                ("_WIN32_WINNT", "0x0602")
-            ],
+            extra_compile_args=MODULES_CFLAGS,
         ),
-    ])
-else:
-    ext = [
-            Extension(
-                "winloop.loop",
-                sources=[
-                    "winloop/loop.pyx",
-                ],
-                extra_compile_args=MODULES_CFLAGS
-            ),
-        ]
+    ]
 
 setup_requires = []
 
-if not (_ROOT / 'winloop' / 'loop.c').exists() or '--cython-always' in sys.argv:
+if not (_ROOT / "winloop" / "loop.c").exists() or "--cython-always" in sys.argv:
     # No Cython output, require Cython to build.
     setup_requires.append(CYTHON_DEPENDENCY)
 
 
 setup(
     version=VERSION,
-    cmdclass={
-        'sdist': uvloop_sdist,
-        'build_ext': uvloop_build_ext
-    },
+    cmdclass={"sdist": uvloop_sdist, "build_ext": uvloop_build_ext},
     ext_modules=ext,
-    setup_requires=setup_requires
+    setup_requires=setup_requires,
 )

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -46,7 +46,7 @@ class _TestAioHTTP:
 
         self.loop.run_until_complete(test())
         self.loop.run_until_complete(runner.cleanup())
-    
+
     def test_aiohttp_graceful_shutdown(self):
         # NOTE: This Might Already be solved I haven't checked yet - Vizonex
         if sys.version_info == (3, 12):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -174,7 +174,10 @@ class _TestBase:
         self.assertLess(finished - started, 0.3)
         self.assertGreater(finished - started, 0.04)
 
-    @unittest.skipIf(sys.version_info[:2] == (3, 12), "uvloop also suffers from the same problem it's not just a winloop problem")
+    @unittest.skipIf(
+        sys.version_info[:2] == (3, 12),
+        "uvloop also suffers from the same problem it's not just a winloop problem",
+    )
     def test_call_later_2(self):
         # Test that loop.call_later triggers an update of
         # libuv cached time.

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -992,7 +992,6 @@ class Test_UV_Process(_TestProcess, tb.UVTestCase):
         """)
         subprocess.run([sys.executable, "-c", script], check=True)
 
-   
 
 class Test_AIO_Process(_TestProcess, tb.AIOTestCase):
     pass

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -405,7 +405,6 @@ class _TestTCP:
 
         self.loop.run_until_complete(start_server())
 
-
     def test_create_connection_open_con_addr(self):
         async def client(addr):
             reader, writer = await asyncio.open_connection(*addr)

--- a/winloop/_testbase.py
+++ b/winloop/_testbase.py
@@ -1,7 +1,6 @@
 """Test utilities. Don't use outside of the winloop project."""
 
 import asyncio
-import asyncio.events
 import collections
 import contextlib
 import gc

--- a/winloop/loop.pyi
+++ b/winloop/loop.pyi
@@ -1,49 +1,41 @@
 import asyncio
 import ssl
-import sys
 from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
 from typing import (
     IO,
     Any,
-    Awaitable,
     Callable,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
     TypeVar,
-    Union,
     overload,
 )
+from collections.abc import Awaitable, Generator, Sequence
 
 _T = TypeVar("_T")
-_Context = Dict[str, Any]
+_Context = dict[str, Any]
 _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, _Context], Any]
-_SSLContext = Union[bool, None, ssl.SSLContext]
+_SSLContext = bool | None | ssl.SSLContext
 _ProtocolT = TypeVar("_ProtocolT", bound=asyncio.BaseProtocol)
 
 class Loop:
     def call_soon(
-        self, callback: Callable[..., Any], *args: Any, context: Optional[Any] = ...
+        self, callback: Callable[..., Any], *args: Any, context: Any | None = ...
     ) -> asyncio.Handle: ...
     def call_soon_threadsafe(
-        self, callback: Callable[..., Any], *args: Any, context: Optional[Any] = ...
+        self, callback: Callable[..., Any], *args: Any, context: Any | None = ...
     ) -> asyncio.Handle: ...
     def call_later(
         self,
         delay: float,
         callback: Callable[..., Any],
         *args: Any,
-        context: Optional[Any] = ...,
+        context: Any | None = ...,
     ) -> asyncio.TimerHandle: ...
     def call_at(
         self,
         when: float,
         callback: Callable[..., Any],
         *args: Any,
-        context: Optional[Any] = ...,
+        context: Any | None = ...,
     ) -> asyncio.TimerHandle: ...
     def time(self) -> float: ...
     def stop(self) -> None: ...
@@ -56,55 +48,52 @@ class Loop:
     def create_future(self) -> asyncio.Future[Any]: ...
     def create_task(
         self,
-        coro: Union[Awaitable[_T], Generator[Any, None, _T]],
+        coro: Awaitable[_T] | Generator[Any, None, _T],
         *,
-        name: Optional[str] = ...,
+        name: str | None = ...,
     ) -> asyncio.Task[_T]: ...
     def set_task_factory(
         self,
-        factory: Optional[
-            Callable[
-                [asyncio.AbstractEventLoop, Generator[Any, None, _T]],
-                asyncio.Future[_T],
-            ]
-        ],
+        factory: Callable[
+            [asyncio.AbstractEventLoop, Generator[Any, None, _T]], asyncio.Future[_T]
+        ]
+        | None,
     ) -> None: ...
     def get_task_factory(
         self,
-    ) -> Optional[
+    ) -> (
         Callable[
             [asyncio.AbstractEventLoop, Generator[Any, None, _T]], asyncio.Future[_T]
         ]
-    ]: ...
+        | None
+    ): ...
     @overload
     def run_until_complete(self, future: Generator[Any, None, _T]) -> _T: ...
     @overload
     def run_until_complete(self, future: Awaitable[_T]) -> _T: ...
     async def getaddrinfo(
         self,
-        host: Optional[Union[str, bytes]],
-        port: Optional[Union[str, bytes, int]],
+        host: str | bytes | None,
+        port: str | bytes | int | None,
         *,
         family: int = ...,
         type: int = ...,
         proto: int = ...,
         flags: int = ...,
-    ) -> List[
-        Tuple[
+    ) -> list[
+        tuple[
             AddressFamily,
             SocketKind,
             int,
             str,
-            Union[Tuple[str, int], Tuple[str, int, int, int]],
+            tuple[str, int] | tuple[str, int, int, int],
         ]
     ]: ...
     async def getnameinfo(
         self,
-        sockaddr: Union[
-            Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]
-        ],
+        sockaddr: tuple[str, int] | tuple[str, int, int] | tuple[str, int, int, int],
         flags: int = ...,
-    ) -> Tuple[str, str]: ...
+    ) -> tuple[str, str]: ...
     async def start_tls(
         self,
         transport: asyncio.BaseTransport,
@@ -112,15 +101,15 @@ class Loop:
         sslcontext: ssl.SSLContext,
         *,
         server_side: bool = ...,
-        server_hostname: Optional[str] = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        server_hostname: str | None = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
     ) -> asyncio.BaseTransport: ...
     @overload
     async def create_server(
         self,
         protocol_factory: asyncio.events._ProtocolFactory,
-        host: Optional[Union[str, Sequence[str]]] = ...,
+        host: str | Sequence[str] | None = ...,
         port: int = ...,
         *,
         family: int = ...,
@@ -128,10 +117,10 @@ class Loop:
         sock: None = ...,
         backlog: int = ...,
         ssl: _SSLContext = ...,
-        reuse_address: Optional[bool] = ...,
-        reuse_port: Optional[bool] = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        reuse_address: bool | None = ...,
+        reuse_port: bool | None = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
         start_serving: bool = ...,
     ) -> asyncio.AbstractServer: ...
     @overload
@@ -146,10 +135,10 @@ class Loop:
         sock: socket = ...,
         backlog: int = ...,
         ssl: _SSLContext = ...,
-        reuse_address: Optional[bool] = ...,
-        reuse_port: Optional[bool] = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        reuse_address: bool | None = ...,
+        reuse_port: bool | None = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
         start_serving: bool = ...,
     ) -> asyncio.AbstractServer: ...
     @overload
@@ -164,10 +153,10 @@ class Loop:
         proto: int = ...,
         flags: int = ...,
         sock: None = ...,
-        local_addr: Optional[Tuple[str, int]] = ...,
-        server_hostname: Optional[str] = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        local_addr: tuple[str, int] | None = ...,
+        server_hostname: str | None = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
     ) -> tuple[asyncio.BaseProtocol, _ProtocolT]: ...
     @overload
     async def create_connection(
@@ -182,36 +171,36 @@ class Loop:
         flags: int = ...,
         sock: socket,
         local_addr: None = ...,
-        server_hostname: Optional[str] = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        server_hostname: str | None = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
     ) -> tuple[asyncio.BaseProtocol, _ProtocolT]: ...
     async def create_unix_server(
         self,
         protocol_factory: asyncio.events._ProtocolFactory,
-        path: Optional[str] = ...,
+        path: str | None = ...,
         *,
         backlog: int = ...,
-        sock: Optional[socket] = ...,
+        sock: socket | None = ...,
         ssl: _SSLContext = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
         start_serving: bool = ...,
     ) -> asyncio.AbstractServer: ...
     async def create_unix_connection(
         self,
         protocol_factory: Callable[[], _ProtocolT],
-        path: Optional[str] = ...,
+        path: str | None = ...,
         *,
         ssl: _SSLContext = ...,
-        sock: Optional[socket] = ...,
-        server_hostname: Optional[str] = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        sock: socket | None = ...,
+        server_hostname: str | None = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
     ) -> tuple[asyncio.BaseProtocol, _ProtocolT]: ...
     def default_exception_handler(self, context: _Context) -> None: ...
-    def get_exception_handler(self) -> Optional[_ExceptionHandler]: ...
-    def set_exception_handler(self, handler: Optional[_ExceptionHandler]) -> None: ...
+    def get_exception_handler(self) -> _ExceptionHandler | None: ...
+    def set_exception_handler(self, handler: _ExceptionHandler | None) -> None: ...
     def call_exception_handler(self, context: _Context) -> None: ...
     def add_reader(self, fd: Any, callback: Callable[..., Any], *args: Any) -> None: ...
     def remove_reader(self, fd: Any) -> None: ...
@@ -220,7 +209,7 @@ class Loop:
     async def sock_recv(self, sock: socket, nbytes: int) -> bytes: ...
     async def sock_recv_into(self, sock: socket, buf: bytearray) -> int: ...
     async def sock_sendall(self, sock: socket, data: bytes) -> None: ...
-    async def sock_accept(self, sock: socket) -> Tuple[socket, _RetAddress]: ...
+    async def sock_accept(self, sock: socket) -> tuple[socket, _RetAddress]: ...
     async def sock_connect(self, sock: socket, address: _Address) -> None: ...
     async def sock_recvfrom(self, sock: socket, bufsize: int) -> bytes: ...
     async def sock_recvfrom_into(
@@ -235,8 +224,8 @@ class Loop:
         sock: socket,
         *,
         ssl: _SSLContext = ...,
-        ssl_handshake_timeout: Optional[float] = ...,
-        ssl_shutdown_timeout: Optional[float] = ...,
+        ssl_handshake_timeout: float | None = ...,
+        ssl_shutdown_timeout: float | None = ...,
     ) -> tuple[asyncio.BaseProtocol, _ProtocolT]: ...
     async def run_in_executor(
         self, executor: Any, func: Callable[..., _T], *args: Any
@@ -245,7 +234,7 @@ class Loop:
     async def subprocess_shell(
         self,
         protocol_factory: Callable[[], _ProtocolT],
-        cmd: Union[bytes, str],
+        cmd: bytes | str,
         *,
         stdin: Any = ...,
         stdout: Any = ...,
@@ -274,21 +263,21 @@ class Loop:
     async def create_datagram_endpoint(
         self,
         protocol_factory: Callable[[], _ProtocolT],
-        local_addr: Optional[Tuple[str, int]] = ...,
-        remote_addr: Optional[Tuple[str, int]] = ...,
+        local_addr: tuple[str, int] | None = ...,
+        remote_addr: tuple[str, int] | None = ...,
         *,
         family: int = ...,
         proto: int = ...,
         flags: int = ...,
-        reuse_address: Optional[bool] = ...,
-        reuse_port: Optional[bool] = ...,
-        allow_broadcast: Optional[bool] = ...,
-        sock: Optional[socket] = ...,
+        reuse_address: bool | None = ...,
+        reuse_port: bool | None = ...,
+        allow_broadcast: bool | None = ...,
+        sock: socket | None = ...,
     ) -> tuple[asyncio.BaseProtocol, _ProtocolT]: ...
     async def shutdown_asyncgens(self) -> None: ...
     async def shutdown_default_executor(
         self,
-        timeout: Optional[float] = ...,
+        timeout: float | None = ...,
     ) -> None: ...
     # Loop doesn't implement these, but since they are marked as abstract in typeshed,
     # we have to put them in so mypy thinks the base methods are overridden
@@ -297,7 +286,7 @@ class Loop:
         transport: asyncio.BaseTransport,
         file: IO[bytes],
         offset: int = ...,
-        count: Optional[int] = ...,
+        count: int | None = ...,
         *,
         fallback: bool = ...,
     ) -> int: ...
@@ -306,7 +295,7 @@ class Loop:
         sock: socket,
         file: IO[bytes],
         offset: int = ...,
-        count: Optional[int] = ...,
+        count: int | None = ...,
         *,
         fallback: bool = ...,
     ) -> int: ...


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

This uses ruff to upgrade annotations from 3.9 to 3.10 but also attempts to use collections.abc instead of typing for some deprecated attributes

## Are there changes in behavior for the user?

if you are attempting to __cherrypick or backport 3.9__ try using `from __future__ import annotations` it should be enough to make winloop backwards compatible. I do not see a need to maintain this version anymore as it puts more stress on me than I would like to receive out of this project.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
