### PR TITLE
Fix start_tls() loses StreamReader buffer data

### DIFF
--- a/winloop/loop.pyx
+++ b/winloop/loop.pyx
@@ -1713,6 +1713,16 @@ cdef class Loop:
             ssl_shutdown_timeout=ssl_shutdown_timeout,
             call_connection_made=False)
 
+        stream_buff = None
+        if hasattr(protocol, '_stream_reader'):
+            stream_reader = protocol._stream_reader
+            if stream_reader is not None:
+                stream_buff = getattr(stream_reader, '_buffer', None)
+
+        if stream_buff is not None:
+            ssl_protocol._incoming.write(stream_buff)
+            stream_buff.clear()
+
         # Pause early so that "ssl_protocol.data_received()" doesn't
         # have a chance to get called before "ssl_protocol.connection_made()".
         transport.pause_reading()


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR fixes a critical issue where buffered data in StreamReader is lost when upgrading a connection to TLS using StreamWriter.start_tls() or loop.start_tls(), causing the call to hang indefinitely. The issue exists in both asyncio (see python/cpython#142352) and uvloop.

The main focus is to verify and guarantee that any data buffered before upgrading a connection to TLS is not lost and is correctly transferred. These changes are effectively a port of https://github.com/python/cpython/pull/142354 with absolutely no difference, except for the test that creates a TCP server, establishes a connection, buffers data, performs a TLS upgrade, and verifies that all messages (both pre-upgrade and post-upgrade) are received correctly.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

Nope.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
Fixes #102 

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
