### PR TITLE
Fix race conditions on `loop._ready_len`

### DIFF
--- a/winloop/loop.pxd
+++ b/winloop/loop.pxd
@@ -49,7 +49,6 @@ cdef class Loop:
         object _default_executor
         object _ready
         set _queued_streams, _executing_streams
-        Py_ssize_t _ready_len
 
         set _servers
 


### PR DESCRIPTION
## What do these changes do?

This is a simple PR that fixes MagicStack/uvloop#720 by removing `loop._ready_len` in favor of `len(loop._ready)`. The attribute was probably added as a premature optimization (it does not affect performance even in edge cases), but it leads to race conditions both between worker threads calling `loop.call_soon_threadsafe()` and between any such worker thread and the event loop, since `loop._ready_len` is updated in a non-thread-safe manner (free-threading).

## Are there changes in behavior for the user?

Since the attribute is not public (and according to GitHub search, it has never been used by anyone else), no.

## Is it a substantial burden for the maintainers to support this?

No, this PR mirrors MagicStack/uvloop#721.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
