### PR TITLE
speedup Context.run by adding in new C Functions for calling it

### DIFF
--- a/winloop/includes/compat.h
+++ b/winloop/includes/compat.h
@@ -118,6 +118,7 @@ int getuid() {
 #endif
 
 
+/* TODO: (Vizonex) add static keyword to these functions */
 #if PY_VERSION_HEX < 0x03070100
 
 PyObject * Context_CopyCurrent(void) {
@@ -147,6 +148,133 @@ int Context_Exit(PyObject *ctx) {
 }
 
 #endif
+
+
+/* Originally apart of loop.pyx via calling context.run 
+moved here so we can began optimizing more 
+reason why something like this is more costly is because
+we have to find the .run method if these were C Functions instead
+This Call would no longer be needed and we skip right to the 
+meat of the function (run) immediately however, we can go further 
+to optimize that code too.
+
+Before:
+cdef inline run_in_context1(context, method, arg):
+    Py_INCREF(method)
+    try:
+        return context.run(method, arg)
+    finally:
+        Py_DECREF(method)
+
+After:
+cdef inline run_in_context1(context, method, arg):
+    Py_INCREF(method)
+    try:
+        return Context_RunNoArgs(context, method)
+    finally:
+        Py_DECREF(method)
+*/
+
+/* Context.run is literally this code right here referenced from python 3.15.1
+
+static PyObject *
+context_run(PyObject *self, PyObject *const *args,
+            Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyThreadState *ts = _PyThreadState_GET();
+
+    if (nargs < 1) {
+        _PyErr_SetString(ts, PyExc_TypeError,
+                         "run() missing 1 required positional argument");
+        return NULL;
+    }
+
+    if (_PyContext_Enter(ts, self)) {
+        return NULL;
+    }
+
+    PyObject *call_result = _PyObject_VectorcallTstate(
+        ts, args[0], args + 1, nargs - 1, kwnames);
+
+    if (_PyContext_Exit(ts, self)) {
+        Py_XDECREF(call_result);
+        return NULL;
+    }
+
+    return call_result;
+}
+
+As we can see this code is not very expensive to maintain 
+at all and can be simply reproduced and improved upon 
+for our needs of being faster. 
+
+Will name them after the different object calls made
+to keep things less confusing. 
+We also eliminate needing to 
+find the run method in the ContextVar by doing so.
+*/
+
+static PyObject* Context_RunNoArgs(PyObject* context, PyObject* method){
+    /* NOTE: Were looking for -1 but we can also say it's not 
+    a no-zero value so we could even treat it as a true case... */
+    if (Context_Enter(context)){
+        return NULL;
+    }
+
+    #if PY_VERSION_HEX >= 0x030a0000
+    PyObject* call_result = PyObject_CallNoArgs(method);
+    #else 
+    PyObject* call_result = PyObject_CallFunctionObjArgs(method, NULL);
+    #endif
+
+    if (Context_Exit(context)){
+        Py_XDECREF(call_result);
+        return NULL;
+    }
+
+    return call_result;
+}
+
+static PyObject* Context_RunOneArg(PyObject* context, PyObject* method, PyObject* arg){
+    if (Context_Enter(context)){
+        return NULL;
+    }
+    /* Introduced in 3.9 */
+    /* NOTE: Kept around backwards compatability since the same features are planned for uvloop */
+    #if PY_VERSION_HEX >= 0x03090000
+        PyObject* call_result = PyObject_CallOneArg(method, arg);
+    #else /* verison < 3.9 */
+        PyObject* call_result = PyObject_CallFunctionObjArgs(method, arg, NULL);
+    #endif
+    if (Context_Exit(context)){
+        Py_XDECREF(call_result);
+        return NULL;
+    }
+    return call_result;
+}
+
+static PyObject* Context_RunTwoArgs(PyObject* context, PyObject* method, PyObject* arg1, PyObject* arg2){
+    /* Cython can't really do this PyObject array packing so writing this in C 
+    has a really good advantage */
+    if (Context_Enter(context)){
+        return NULL;
+    }
+    #if PY_VERSION_HEX >= 0x03090000
+    /* begin packing for call... */    
+    PyObject* args[2];
+    args[0] = arg1;
+    args[1] = arg2;
+    PyObject* call_result = PyObject_Vectorcall(method, args, 2, NULL);
+    #else 
+    PyObject* call_result = PyObject_CallFunctionObjArgs(method, arg1, arg2, NULL);    
+    #endif 
+    if (Context_Exit(context)){
+        Py_XDECREF(call_result);
+        return NULL;
+    }
+    return call_result;
+}
+
 
 /* inlined from cpython/Modules/signalmodule.c
  * https://github.com/python/cpython/blob/v3.13.0a6/Modules/signalmodule.c#L1931-L1951

--- a/winloop/includes/python.pxd
+++ b/winloop/includes/python.pxd
@@ -31,6 +31,13 @@ cdef extern from "includes/compat.h":
     int Context_Enter(object) except -1
     int Context_Exit(object) except -1
 
+    # Custom functions for making context.run faster.
+    # meaning more speed for all handle calls being made
+    object Context_RunNoArgs(object context, object method)
+    object Context_RunOneArg(object context, object method, object arg)
+    object Context_RunTwoArgs(object context, object method, object arg1, object arg2)
+
+
     void PyOS_BeforeFork()
     void PyOS_AfterFork_Parent()
     void PyOS_AfterFork_Child()

--- a/winloop/loop.pyx
+++ b/winloop/loop.pyx
@@ -33,7 +33,11 @@ from .includes.python cimport (PY_VERSION_HEX, Context_CopyCurrent,
                                PyMemoryView_FromObject, PyObject_CallNoArgs,
                                PyOS_AfterFork_Child, PyOS_AfterFork_Parent,
                                PyOS_BeforeFork, PyUnicode_EncodeFSDefault,
-                               PyUnicode_FromString, _Py_RestoreSignals)
+                               PyUnicode_FromString, _Py_RestoreSignals,
+                               Context_RunNoArgs,
+                               Context_RunOneArg,
+                               Context_RunTwoArgs
+                               )
 
 # NOTE: Keep if we need to revert at any point in time...
 from ._noop import noop
@@ -103,7 +107,7 @@ cdef inline run_in_context(context, method):
     # See also: edgedb/edgedb#2222
     Py_INCREF(method)
     try:
-        return context.run(method)
+        return Context_RunNoArgs(context, method)
     finally:
         Py_DECREF(method)
 
@@ -111,7 +115,7 @@ cdef inline run_in_context(context, method):
 cdef inline run_in_context1(context, method, arg):
     Py_INCREF(method)
     try:
-        return context.run(method, arg)
+        return Context_RunOneArg(context, method, arg)
     finally:
         Py_DECREF(method)
 
@@ -119,7 +123,7 @@ cdef inline run_in_context1(context, method, arg):
 cdef inline run_in_context2(context, method, arg1, arg2):
     Py_INCREF(method)
     try:
-        return context.run(method, arg1, arg2)
+        return Context_RunTwoArgs(context, method, arg1, arg2)
     finally:
         Py_DECREF(method)
 


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes make use of a new implementation that gets rid of needing to find the `Context.run` method and instead uses a C Implementation of it to speedup all Handles significantly. It may not seem like a great improvement but over the course of making and running many handles the time saved becomes significant. I have added a deeper explanation left in `compat.h`
if anybody wants to hear the nitty-gritty details.

## Are there changes in behavior for the user?

- faster handles Specifically ones that use `contextvars` so `Handle` and `TimerHandle` should see speed improvements now that the run method is no longer needed to be hunted down before calling upon a target function.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
