### PR TITLE
Removed deprecated `pkg_resources` from setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test = [
     'mypy>=0.800'
 ]
 dev = [
+    'packaging',
     'setuptools>=60',
     'Cython==3.2.4',
 ]
@@ -59,6 +60,7 @@ docs = [
 
 [build-system]
 requires = [
+    "packaging",
     "setuptools>=60",
     "wheel",
     "Cython==3.2.4",

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,8 @@ class uvloop_build_ext(build_ext):
                         need_cythonize = True
 
         if need_cythonize:
-            import pkg_resources
+            from packaging.requirements import Requirement
+            from packaging.version import Version
 
             # Double check Cython presence in case setup_requires
             # didn't go into effect (most likely because someone
@@ -131,8 +132,8 @@ class uvloop_build_ext(build_ext):
                     )
                 )
 
-            cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
-            if Cython.__version__ not in cython_dep:
+            cython_dep = Requirement(CYTHON_DEPENDENCY)
+            if not cython_dep.specifier.contains(Version(Cython.__version__)):
                 raise RuntimeError(
                     "uvloop requires {}, got Cython=={}".format(
                         CYTHON_DEPENDENCY, Cython.__version__


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

In the [recent](https://setuptools.pypa.io/en/stable/history.html#v82-0-0) setuptools version, the deprecated `pkg_resources` has been removed, resulting in a broken build. It needs to be replaced with `packaging`.

## Are there changes in behavior for the user?

Nope

## Is it a substantial burden for the maintainers to support this?

Nope

## Related issue number

--

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
