### PR TITLE
upgrade cibuildwheels to run in parallel for better speed

### DIFF
--- a/.github/workflows/run-cibuildwheel.yml
+++ b/.github/workflows/run-cibuildwheel.yml
@@ -1,4 +1,4 @@
-# Borrowing from pycares/cyares
+# borrowing from pycares again due to the complexity of building wheels being rather annoying.
 
 on:
   workflow_call:
@@ -13,37 +13,61 @@ on:
         required: false
         default: false
         type: boolean
-env:
-  # PyPy is currently unsupported.
-  CIBW_SKIP: pp*
-
 
 jobs:
+  generate-wheels-matrix:
+    # Create a matrix of all architectures & versions to build.
+    # This enables the next step to run cibuildwheel in parallel.
+    # From https://iscinumpy.dev/post/cibuildwheel-2-10-0/#only-210
+    name: Generate wheels matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install cibuildwheel
+      # Nb. keep cibuildwheel version pin consistent with job below
+        run: pipx install cibuildwheel==3.2.1
+      - id: set-matrix
+        # Trimmed out setupmatrix for just windows but I might look at compiling other oses just for fun 
+        # to let others test what it would be like if uvloop supported windows. It's very tempting...
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform windows --archs AMD64 \
+              | jq -nRc '{"only": inputs, "os": "windows-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --archs ARM64 \
+              | jq -nRc '{"only": inputs, "os": "windows-11-arm"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
   build_wheels:
-    name: Build wheels for ${{ matrix.name }}
+    name: Build wheels for ${{ matrix.only }}
     runs-on: ${{ matrix.os }}
+    needs: generate-wheels-matrix
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
-        include:
-        # NOTE: This does compile on Linux but linux fails pytest
-          - name: Windows
-            os: windows-latest
-          - name: Windows arm64
-            os: windows-11-arm
+        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: all
       - name: Enable CPython prerelease
         if: ${{ inputs.prerelease-pythons }}
         run: echo "CIBW_ENABLE=cpython-prerelease" >> $GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         with:
+          only: ${{ matrix.only }}
           output-dir: dist
-          
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.only }}
           path: dist/*.whl


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

This change modifies the current cibuildwheels and makes it run in parallel so instead of taking 15 minutes to compile this should only take around 8 minutes depending on the concurrency of the workflows.

> [!NOTE]
> I might change my mind about the possibility of distributing wheels for linux and apple users test out winloop mainly as a simulation. I'll ask one of the uvloop maintainers first if that is ok first this could give us the opportunity even to upgrade uvloop's workflows as a bonus.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
