### PR TITLE
upload wheels onto release page when new versions are made.

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -16,6 +16,22 @@ jobs:
   build_sdist:
     uses: ./.github/workflows/run-sdist.yml
 
+  upload_github:
+    needs: [build_wheels, build_sdist]
+    if: github.event_name == 'release' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Upload Wheels To GitHub Release Page
+        uses: softprops/action-gh-release@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: dist/*
+
   upload_pypi:
     needs: [build_wheels, build_sdist]
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

This change adds the ability to upload wheels onto winloop's release page. This would be a good thing to have incase something like pypi has a random blackout or users want to go through different wheels manually.

## Are there changes in behavior for the user?

This does not change anything internally and is related to external or workflow practices unrelated to uvloop & winloop's future merge.

## Is it a substantial burden for the maintainers to support this?

Can be related to #20 #41 when you think about it...

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
