### PR TITLE
chore: fix capitalization and codespell typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
               .*\.pyx\.c
           )$
         args:
-          - --ignore-words-list=asince,bu,hist,nd,noe,ot,te,ue,wan,wile,ans,crate,cas,trough,conection,exection,fo,ist,nam,no,onot,pres,ser,set,start,uint,axcept,alloc,ba,cycl,fulllist,indx,isin,inout,les,ls,mut,nin,releated,sice,splited,unser,vas,wether,assertin,asend
+          - --ignore-words-list=assertin, asend
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.16.0

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,4 +1,4 @@
-Copyright (C) 2023-present Vizonex, the winloop authors and winloop contributors.
+Copyright (C) 2023-present Vizonex, the Winloop authors and Winloop contributors.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +188,7 @@ Copyright (C) 2023-present Vizonex, the winloop authors and winloop contributors
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2023-present Vizonex, the winloop authors and winloop contributors.
+   Copyright (C) 2023-present Vizonex, the Winloop authors and Winloop contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (C) 2023-present Vizonex , winloop authors and the winloop contributors.
+Copyright (C) 2023-present Vizonex, Winloop authors and the Winloop contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR includes cleanup and localization fixes across two separate commits:
1. Capitalized the "Winloop" name properly in the license files.
2. Removed the redundant `--ignore-words-list` arguments from `.pre-commit-config.yaml`.

## Are there changes in behavior for the user?

No. These are strictly documentation, license formatting, and configuration updates.

## Is it a substantial burden for the maintainers to support this?

No. Cleaning up the `codespell` configuration reduces maintenance overhead by removing an unnecessary ignore-list block.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests are not needed
- [x] Documentation reflects the changes
